### PR TITLE
Add dataset-specific READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,24 +48,24 @@ Here, we provide 2 inductive LP datasets. Each dataset in `./data` consists of 4
 
 `small` dataset stats:
 
-| Split                | Entities  | Relations   | Triples |
-|----------------------|-----------|-------------|---------|
-| Train                | 10,230    | 96          | 78,616  |
-| Inference            | 6,653     | 96 (subset) | 20,960  |
-| Inference validation | 6,653     | 96 (subset) | 2,908   |
-| Inference test       | 6,653     | 96 (subset) | 2,902   |
-| Held-out test set    | 6,653     | 96 (subset) | 2,894   |
+| Split                |  Entities | Relations   | Triples |
+|----------------------|----------:|-------------|--------:|
+| Train                |    10,230 | 96          |  78,616 |
+| Inference            |     6,653 | 96 (subset) |  20,960 |
+| Inference validation |     6,653 | 96 (subset) |   2,908 |
+| Inference test       |     6,653 | 96 (subset) |   2,902 |
+| Held-out test set    |     6,653 | 96 (subset) |   2,894 |
 
 
 `large` dataset stats:
 
 | Split                | Entities | Relations         | Triples |
-|----------------------|----------|-------------------|---------|
-| Train                | 46,626   | 130               | 202,446 |
-| Inference            | 29,246   | 130 (subset)      | 77,044  |
-| Inference validation | 29,246   | 130 (subset)      | 10,179  |
-| Inference test       | 29,246   | 130 (subset)      | 10,184  |
-| Held-out test set    | 29,246   | 130 (subset)      | 10,172  |
+|----------------------|---------:|-------------------|--------:|
+| Train                |   46,626 | 130               | 202,446 |
+| Inference            |   29,246 | 130 (subset)      |  77,044 |
+| Inference validation |   29,246 | 130 (subset)      |  10,179 |
+| Inference test       |   29,246 | 130 (subset)      |  10,184 |
+| Held-out test set    |   29,246 | 130 (subset)      |  10,172 |
 
 
 ## Baselines

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,2 @@
+# Dataset
+

--- a/data/large/README.md
+++ b/data/large/README.md
@@ -1,0 +1,9 @@
+# Large Dataset
+
+| Split                                            | Entities | Relations         | Triples |
+|--------------------------------------------------|---------:|-------------------|--------:|
+| [Train](train.txt)                               |   46,626 | 130               | 202,446 |
+| [Inference](inference.txt)                       |   29,246 | 130 (subset)      |  77,044 |
+| [Inference validation](inference_validation.txt) |   29,246 | 130 (subset)      |  10,179 |
+| [Inference test](inference_test.txt)             |   29,246 | 130 (subset)      |  10,184 |
+| Held-out test set                                |   29,246 | 130 (subset)      |  10,172 |

--- a/data/small/README.md
+++ b/data/small/README.md
@@ -1,0 +1,9 @@
+# Small Dataset
+
+| Split                                            |  Entities | Relations   | Triples |
+|--------------------------------------------------|----------:|-------------|--------:|
+| [Train](train.txt)                               |    10,230 | 96          |  78,616 |
+| [Inference](inference.txt)                       |     6,653 | 96 (subset) |  20,960 |
+| [Inference validation](inference_validation.txt) |     6,653 | 96 (subset) |   2,908 |
+| [Inference test](inference_test.txt)             |     6,653 | 96 (subset) |   2,902 |
+| Held-out test set                                |     6,653 | 96 (subset) |   2,894 |


### PR DESCRIPTION
The main README is quite big, so it would probably be good to offload some of the content to the folders where the data is.